### PR TITLE
add more configurable parameters for build

### DIFF
--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -2,7 +2,7 @@ name: rpm-build
 
 on:
   pull_request:
-    branches: [ supervm-main ]
+    branches: [supervm-main, supervm-releases/**]
   
 jobs:
   build:
@@ -24,6 +24,9 @@ jobs:
       - name: Setup job yaml 
         run: |
           sed -e "s#{{ PR_NUMBER }}#${{ steps.vars.outputs.PR_NUMBER }}#g" ${{ steps.vars.outputs.TEMPLATE_FILE }} > ${{ steps.vars.outputs.JOB_FILE }}
+          sed -i "s#{{ GITHUB_REF }}##g" ${{ steps.vars.outputs.JOB_FILE }}
+          sed -i "s#{{ OVIRT_REPO }}#http://172.21.7.2/supervm/21.0.1/prolinux/8/arch/x86_64/#g" ${{ steps.vars.outputs.JOB_FILE }}
+          sed -i "s#{{ TARGET_DIR }}##g" ${{ steps.vars.outputs.JOB_FILE }}
       - name: Run ovirt-web-ui build job
         run: kubectl create -f ${{ steps.vars.outputs.JOB_FILE }}
       - name: Wait the job to be finished


### PR DESCRIPTION
- OVIRT_REPO: build시 ovirt-engine-nodejs-modules을 설치하기 위해 ovirt repository 주소
- GITHUB_REF: 해당 변수가 주어지면 해당 REF로 checkout후 빌드 수행
- TARGET_DIR: rpm을 저장할 directory, PR일때 주어지지 않으면 default로 설정된 공간에 저장
- release branch의 PR에 대해서도 rpm-build test를 수행하도록 수정