### PR TITLE
[276540] 가상머신 포털에서 툴팁으로 인해 스냅샷 아이콘 클릭이 불가능한 현상

### DIFF
--- a/src/components/VmDetails/cards/SnapshotsCard/SnapshotItem.js
+++ b/src/components/VmDetails/cards/SnapshotsCard/SnapshotItem.js
@@ -144,7 +144,7 @@ class SnapshotItem extends React.Component {
             vmId={this.props.vmId}
             trigger={({ onClick }) => (
               <SnapshotAction key='restore' id={`${this.props.id}-restore`} onClick={onClick} disabled={isRestoreDisabled}>
-                <Tooltip id={`${this.props.id}-restore-tt`} tooltip={msg.snapshotRestore()}>
+                <Tooltip id={`${this.props.id}-restore-tt`} tooltip={msg.snapshotRestore()} placement={'left'}>
                   <Icon type='fa' name='play-circle' />
                 </Tooltip>
               </SnapshotAction>
@@ -160,7 +160,7 @@ class SnapshotItem extends React.Component {
             onDelete={this.props.onSnapshotDelete}
             trigger={({ onClick }) => (
               <SnapshotAction key='delete' id={`${this.props.id}-delete`} disabled={isActionsDisabled} onClick={onClick}>
-                <Tooltip id={`${this.props.id}-delete-tt`} tooltip={msg.snapshotDelete()}>
+                <Tooltip id={`${this.props.id}-delete-tt`} tooltip={msg.snapshotDelete()} placement={'left'}>
                   <Icon type='pf' name='delete' />
                 </Tooltip>
               </SnapshotAction>

--- a/src/components/tooltips/Tooltip.js
+++ b/src/components/tooltips/Tooltip.js
@@ -8,7 +8,7 @@ const Tooltip = ({ id, tooltip, placement, children, ...rest }) => {
       overlay={
         <PFTooltip id={id}>{tooltip}</PFTooltip>
       }
-      placement={placement || 'top'}
+      placement={placement || 'left'}
       {...rest}
     >
       { children }

--- a/src/components/tooltips/Tooltip.js
+++ b/src/components/tooltips/Tooltip.js
@@ -8,7 +8,7 @@ const Tooltip = ({ id, tooltip, placement, children, ...rest }) => {
       overlay={
         <PFTooltip id={id}>{tooltip}</PFTooltip>
       }
-      placement={placement || 'left'}
+      placement={placement || 'top'}
       {...rest}
     >
       { children }


### PR DESCRIPTION
스냅샷 복원, 스냅샷 삭제 버튼의 툴팁 위치를 왼쪽으로 고정하여,

클릭 불가능한 현상 해결하였습니다.